### PR TITLE
replaced all md5sum.txt with md5sum.result

### DIFF
--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -44,7 +44,7 @@ outputs:
     type: File
     format: http://edamontology.org/data_3671
     outputBinding:
-      glob: md5sum.txt
+      glob: md5sum.result
     doc: A text file that contains a single line that is the md5sum of the input file.
 
 baseCommand: [/bin/my_md5sum]

--- a/Dockstore.wdl
+++ b/Dockstore.wdl
@@ -6,7 +6,7 @@ task md5 {
   }
 
  output {
-    File value = "md5sum.txt"
+    File value = "md5sum.result"
  }
 
  runtime {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This is the parameterization of the md5sum tool, a copy is present in this repo 
     },
     "output_file": {
         "class": "File",
-        "path": "/tmp/md5sum.txt"
+        "path": "/tmp/md5sum.result"
     }
 }
 ```

--- a/test.dockstore.json
+++ b/test.dockstore.json
@@ -5,6 +5,6 @@
     },
     "output_file": {
         "class": "File",
-        "path": "/tmp/md5sum.txt"
+        "path": "/tmp/md5sum.result"
     }
 }


### PR DESCRIPTION
This makes the Docker image compatible with the GA4GH workflow examples, which expect `<tool>.result` instead of `<tool>.txt`

Did a test run 
```
dockstore tool launch --local-entry Dockstore.cwl --json test.dockstore.json
```
using a local build with the updated Docker image (and the dockerPull line in `Dockstore.cwl` replaced with the test image) to verify this runs.